### PR TITLE
set function.ReturnType based on signature.ReturnType in Reader.cs

### DIFF
--- a/WinmdToJson/Reader.cs
+++ b/WinmdToJson/Reader.cs
@@ -238,6 +238,9 @@ internal class Reader
                 function.Module = moduleName;
             }
 
+            if (signature.ReturnType != null)
+                function.ReturnType = signature.ReturnType;
+
             if (parameters.Count > 0)
                 function.Parameters = [];
 


### PR DESCRIPTION
Hi,

I'm not sure if you have contribution rules specifically for this repo. I noticed that ReturnType fields are never set in `Reader.ProcessMethods`. I made a tiny change, let me know what you think. 